### PR TITLE
check for document availablity

### DIFF
--- a/src/scripts/direction-reveal.js
+++ b/src/scripts/direction-reveal.js
@@ -22,7 +22,8 @@ const DirectionReveal = function ({
   touchThreshold: touchThreshold = 250
   } = {}) {
 
-  const containers = document.querySelectorAll(selector);
+  const containers = typeof document !== "undefined" ? document.querySelectorAll(selector) : []
+
   let touchStart;
 
 


### PR DESCRIPTION
for usage with static site generators like Gatsby. "document" is not available at build time, this check makes it possible to build pages without failing